### PR TITLE
Add missing test for a ternary with nil without a space before the colon

### DIFF
--- a/lib/pt_testcase.rb
+++ b/lib/pt_testcase.rb
@@ -854,6 +854,11 @@ class ParseTreeTestCase < MiniTest::Unit::TestCase
             "RawParseTree" => [:call, nil, :foo, [:array, [:lit, :bar]]],
             "ParseTree"    => s(:call, nil, :foo, s(:arglist, s(:lit, :bar))))
 
+  add_tests("ternary_nil_no_space",
+            "Ruby"         => "1 ? nil: 1",
+            "RawParseTree" => [:if, [:lit, 1], [:nil], [:lit, 1]],
+            "ParseTree"    => s(:if, s(:lit, 1), s(:nil), s(:lit, 1)))
+
   add_tests("call_arglist_hash",
             "Ruby"         => "o.m(:a => 1, :b => 2)",
             "RawParseTree" => [:call,


### PR DESCRIPTION
This source fails to parse with the latest RubyParser:

```
1 ? nil: 1
```

This is a failing test case for that.
