### PR TITLE
Add a test for a bare hash at end of array (1.9)

### DIFF
--- a/lib/pt_testcase.rb
+++ b/lib/pt_testcase.rb
@@ -4787,4 +4787,18 @@ class ParseTreeTestCase < MiniTest::Unit::TestCase
               "Ruby"         => '?a',
               "RawParseTree" => [:str, "a"],
               "ParseTree"    => s(:str, "a"))
+
+  add_19tests("bare_hash_at_end_of_array",
+              "Ruby"         => "[:a, :b => :c]",
+              "RawParseTree" => [:array,
+                                  [:lit, :a],
+                                  [:hash,
+                                    [:lit, :b],
+                                    [:lit, :c]]],
+              "ParseTree"    => s(:array,
+                                  s(:lit, :a),
+                                  s(:hash,
+                                    s(:lit, :b),
+                                    s(:lit, :c))))
+
 end


### PR DESCRIPTION
Apparently this is a thing now:

```
$ ruby -v
ruby 1.9.2p290 (2011-07-09 revision 32553) [i686-linux]

$ ruby -e "p [:a, :b, :c => :d]"
[:a, :b, {:c=>:d}]
```
