### PR TITLE
Add test for trailing comma in argument list for 1.9

### DIFF
--- a/lib/pt_testcase.rb
+++ b/lib/pt_testcase.rb
@@ -4505,6 +4505,12 @@ class ParseTreeTestCase < MiniTest::Unit::TestCase
                                       s(:lit, :a), s(:lit, 1),
                                       s(:lit, :b), s(:lit, 2)))))
 
+  add_19tests("call_arglist_trailing_comma",
+            "Ruby"         => "a(1,2,3,)",
+            "ParseTree"    => s(:call, nil, :a,
+                                s(:arglist,
+                                  s(:lit, 1), s(:lit, 2), s(:lit, 3))))
+
   add_19tests("call_not_equal",
             "Ruby"         => "a != b",
               "RawParseTree" => [:call, [:vcall, :a], :"!=",


### PR DESCRIPTION
Ruby 1.9 allows for a trailing comma in argument lists:

```
$ ruby -v
ruby 1.9.2p290 (2011-07-09 revision 32553) [i686-linux]
$ ruby -c -e "blah(1,2,3,)"
Syntax OK
```
