### PR TITLE
Add test for regression: "( a (b), c)" fails but works under ruby_parser 2.3.1

### DIFF
--- a/lib/pt_testcase.rb
+++ b/lib/pt_testcase.rb
@@ -2323,6 +2323,13 @@ class ParseTreeTestCase < MiniTest::Unit::TestCase
                                 s(:call, nil, :block_given?, s(:arglist)),
                                 s(:lit, 42), nil))
 
+  add_tests("fcall_inside_parens",
+            "Ruby"         => "( c (d), e)",
+            "ParseTree"    => s(:call,
+                                 nil,
+                                  :c,
+                                   s(:arglist, s(:call, nil, :d, s(:arglist)), s(:call, nil, :e, s(:arglist)))))
+
   add_tests("flip2",
             "Ruby"         => "x = if ((i % 4) == 0)..((i % 3) == 0) then\n  i\nelse\n  nil\nend",
             "RawParseTree" => [:lasgn,


### PR DESCRIPTION
Works fine with Ruby:

```
$ ruby -v
ruby 1.9.3p125 (2012-02-16 revision 34643) [x86_64-darwin11.3.0]
$ ruby -c -e "( a (b), c)"
Syntax OK

$ ruby -v
ruby 1.8.7 (2012-02-08 MBARI 8/0x6770 on patchlevel 358) [i686-darwin11.3.0], MBARI 0x6770, Ruby Enterprise Edition 2012.02
$ ruby -c -e "( a (b), c)"
Syntax OK
```

Works fine with 2.3.1:

```
1.9.3-p125 :001 > require 'ruby_parser'
 => true 
1.9.3-p125 :002 > RubyParser.new.parse "( a (b), c)"
 => s(:call, nil, :a, s(:arglist, s(:call, nil, :b, s(:arglist)), s(:call, nil, :c, s(:arglist)))) 
```

Does not work with master:

```
$ irb
1.9.3-p125 :001 > require 'ruby_parser'
 => true 
1.9.3-p125 :002 > Ruby18Parser.new.parse "( a (b), c)"
Racc::ParseError: 
parse error on value "," (tCOMMA)
    from /Users/collins/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/1.9.1/racc/parser.rb:351:in `on_error'
    from (eval):3:in `_racc_do_parse_c'
    from (eval):3:in `do_parse'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p125@ruby_parser/gems/ruby_parser-3.0.0a1/lib/ruby_parser_extras.rb:779:in `process'
    from (irb):2
    from /Users/collins/.rvm/rubies/ruby-1.9.3-p125/bin/irb:16:in `<main>'
1.9.3-p125 :003 > Ruby19Parser.new.parse "( a (b), c)"
Racc::ParseError: 
parse error on value "," (tCOMMA)
    from /Users/collins/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/1.9.1/racc/parser.rb:351:in `on_error'
    from (eval):3:in `_racc_do_parse_c'
    from (eval):3:in `do_parse'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p125@ruby_parser/gems/ruby_parser-3.0.0a1/lib/ruby_parser_extras.rb:779:in `process'
    from (irb):3
    from /Users/collins/.rvm/rubies/ruby-1.9.3-p125/bin/irb:16:in `<main>'
```
