### PR TITLE
Added parenthesis to fix the structure_remove_begin_1 testcase

### DIFF
--- a/lib/pt_testcase.rb
+++ b/lib/pt_testcase.rb
@@ -2853,7 +2853,7 @@ class ParseTreeTestCase < Minitest::Test
                                   s(:call, nil, :b),
                                   s(:resbody, s(:array),
                                     s(:call, nil, :c)))),
-            "Ruby2Ruby"    => "(a << b rescue c)")
+            "Ruby2Ruby"    => "(a << (b rescue c))")
 
   add_tests("structure_remove_begin_2",
             "Ruby"         => "a = if c\n      begin\n        b\n      rescue\n        nil\n      end\n    end\na",


### PR DESCRIPTION
Hi,

The `structure_remove_begin_1 testcase` testcase in `lib/pt_testcase.rb` is incorrect. Expected code for the supplied sexp is `(a << b rescue c)` when it should be `(a << (b rescue c))`.

Here is the sexp used in that testcase (line 2851):

```
s(:call, s(:call, nil, :a), :<<,
  s(:rescue,
    s(:call, nil, :b),
    s(:resbody, s(:array),
      s(:call, nil, :c))))
```

Notice how the :rescue sexp wraps the argument of the `:<<` call. The problem is that the expected code `(a << b rescue c)` will try to rescue from `a << b` instead of just `b` because of operator precedence. Indeed, looking at the sexp corresponding to the current (incorrect) expected code:

```
RubyParser.new.process "(a << b rescue c)"
```

returns

```
s(:rescue,
  s(:call, s(:call, nil, :a), :<<, s(:call, nil, :b)),
  s(:resbody, s(:array), s(:call, nil, :c)))
```

Notice how the rescue sexp is outside the call this time. This is the correct semantic of the faulty expected code.

Therefore, the expected code should be changed to `(a << (b rescue c))`.

Thanks,
- Bocete
