### PR TITLE
Cache processor/rewrite methods per class

### DIFF
--- a/lib/sexp_processor.rb
+++ b/lib/sexp_processor.rb
@@ -110,6 +110,20 @@ class SexpProcessor
   end
 
   ##
+  # Cache processor methods per class.
+
+  def self.processors
+    @processors ||= {}
+  end
+
+  ##
+  # Cache rewiter methods per class.
+
+  def self.rewriters
+    @rewriters ||= {}
+  end
+
+  ##
   # Creates a new SexpProcessor.  Use super to invoke this
   # initializer from SexpProcessor subclasses, then use the
   # attributes above to customize the functionality of the
@@ -130,16 +144,18 @@ class SexpProcessor
 
     # we do this on an instance basis so we can subclass it for
     # different processors.
-    @processors = {}
-    @rewriters  = {}
+    @processors = self.class.processors
+    @rewriters  = self.class.rewriters
     @context    = []
 
-    public_methods.each do |name|
-      case name
-      when /^process_(.*)/ then
-        @processors[$1.to_sym] = name.to_sym
-      when /^rewrite_(.*)/ then
-        @rewriters[$1.to_sym]  = name.to_sym
+    if @processors.empty?
+      public_methods.each do |name|
+        case name
+        when /^process_(.*)/ then
+          @processors[$1.to_sym] = name.to_sym
+        when /^rewrite_(.*)/ then
+          @rewriters[$1.to_sym]  = name.to_sym
+        end
       end
     end
   end


### PR DESCRIPTION
I am not sure this is worth changing.

Here are my results for 10,000 calls to `SexpProcessor.new` (script below).

Current master (5b5742753b7c1297172be1105f82c99a25e3ae71):
```
                    user     system      total        real
10000 instances  1.050000   0.010000   1.060000 (  1.067324)
```

With this change:
```
                     user     system      total        real
10000 instances  0.020000   0.000000   0.020000 (  0.017636)
```

Obviously there is a difference, but I'm not sure how many people are creating tens of thousands of instances of `SexpProcessor`.

The downside to this is that once the class has been instantiated once, any added methods will not be picked up. I thought to use `method_added` for this, but it turns out it would miss any methods not directly added to the class (e.g. via modules).

Anyway, just throwing it out there.

This was my test script:

```ruby
$LOAD_PATH << "lib"

require 'benchmark'
require 'sexp'
require 'sexp_processor'
TIMES = 10000

Benchmark.bm do |t|
  t.report("#{TIMES} instances") do
    TIMES.times do
      SexpProcessor.new
    end
  end
end
```