### PR TITLE
Handle recursive Sexps in Sexp#inspect

### DIFF
--- a/lib/sexp.rb
+++ b/lib/sexp.rb
@@ -1,3 +1,4 @@
+require 'set'
 $TESTING ||= false # unless defined $TESTING
 
 ##
@@ -150,8 +151,20 @@ class Sexp < Array # ZenTest FULL
     return Sexp.from_array(new)
   end
 
-  def inspect # :nodoc:
-    sexp_str = self.map {|x|x.inspect}.join(', ')
+  def inspect(seen = Set.new) # :nodoc:
+    if seen.include? self.object_id
+      sexp_str = '...'
+    else
+      seen << self.object_id
+      sexp_str = self.map do |x|
+        if x.is_a? Sexp
+          x.inspect seen
+        else
+          x.inspect
+        end
+      end.join(', ')
+    end
+
     if ENV['VERBOSE'] && line then
       "s(#{sexp_str}).line(#{line})"
     else

--- a/test/test_sexp.rb
+++ b/test/test_sexp.rb
@@ -192,6 +192,12 @@ class TestSexp < SexpTestCase # ZenTest FULL
                  k.new(:a, k.new(:b)).inspect)
   end
 
+  def test_inspect_recursive
+      a = s(:a)
+      a << a
+      assert_equal("s(:a, s(...))", a.inspect)
+  end
+
   def test_mass
     assert_equal 1, s(:a).mass
     assert_equal 3, s(:a, s(:b), s(:c)).mass


### PR DESCRIPTION
What do you think about this? On one hand it matches Array behavior and prevents infinite recursion. On the other hand it may mask implementation errors.