### PR TITLE
Use concat instead of splat for creating new Sexps

### DIFF
--- a/lib/sexp.rb
+++ b/lib/sexp.rb
@@ -37,7 +37,7 @@ class Sexp < Array # ZenTest FULL
   def self.from_array a
     ary = Array === a ? a : [a]
 
-    self.new(*ary.map { |x|
+    self.new.concat(ary.map { |x|
                case x
                when Sexp
                  x
@@ -54,7 +54,7 @@ class Sexp < Array # ZenTest FULL
   # same +file+, +line+, and +comment+ as self.
 
   def new(*body)
-    r = self.class.new(*body) # ensures a sexp from map
+    r = self.class.new.concat(body) # ensures a sexp from map
     r.file     = self.file     if self.file
     r.line     = self.line     if self.line
     r.comments = self.comments if self.comments
@@ -62,7 +62,7 @@ class Sexp < Array # ZenTest FULL
   end
 
   def map &blk # :nodoc:
-    self.new(*super(&blk)) # ensures a sexp from map
+    self.new.concat(super(&blk)) # ensures a sexp from map
   end
 
   def == obj # :nodoc:
@@ -278,7 +278,7 @@ class Sexp < Array # ZenTest FULL
   # the values without the node type.
 
   def sexp_body from = 1
-    self.new(*self[from..-1])
+    self.new.concat(self[from..-1])
   end
 
   ##


### PR DESCRIPTION
Originally I was looking into a stack overflow issue, which ended up being due to parsing a huge array (> 20k elements). Apparently it was too large to be splatting into method arguments.

Using `concat` is a bit faster (haven't seen a difference in real life) and doesn't have the stack overflow issue.

Benchmark results:

```
Warming up --------------------------------------
           concat 10    68.518k i/100ms
            splat 10    54.624k i/100ms
          concat 100    66.541k i/100ms
           splat 100    57.279k i/100ms
         concat 1000    43.240k i/100ms
          splat 1000    31.096k i/100ms
        concat 10000     6.662k i/100ms
         splat 10000     3.563k i/100ms
Calculating -------------------------------------
           concat 10    847.336k (± 4.7%) i/s -      4.248M in   5.025032s
            splat 10    689.371k (± 5.3%) i/s -      3.441M in   5.006853s
          concat 100    826.659k (± 8.5%) i/s -      4.126M in   5.033254s
           splat 100    661.797k (±10.6%) i/s -      3.265M in   5.002458s
         concat 1000    533.845k (±13.3%) i/s -      2.638M in   5.060309s
          splat 1000    347.899k (±15.6%) i/s -      1.710M in   5.082546s
        concat 10000     61.158k (±15.4%) i/s -    299.790k in   5.021086s
         splat 10000     31.669k (±15.5%) i/s -    156.772k in   5.085479s
```

Benchmark code:

```
require 'benchmark/ips'
require 'sexp_processor'

arrays = [
  Array.new(10) { 0 },
  Array.new(100) { 0 },
  Array.new(1000) { 0 },
  Array.new(10000) { 0 }
]

Benchmark.ips do |x|
  arrays.each do |array|
    x.report "concat #{array.length}" do
      s.new.concat(array)
    end

    x.report "splat #{array.length}" do
      s.new(*array)
    end
  end
end
```