### PR TITLE
Use alias instead of alias_method

### DIFF
--- a/lib/sexp_matcher.rb
+++ b/lib/sexp_matcher.rb
@@ -156,8 +156,9 @@ class Sexp #:nodoc:
     Not.new arg
   end
 
-  mc = (class << self; self; end)
-  mc.alias_method :-, :not?
+  class << self
+    alias :- :not?
+  end
 
   # TODO: add Sibling factory method?
 


### PR DESCRIPTION
In a project using this gem, CI for Ruby 2.4.9 is failed due to `alias_method`. 

Until Ruby 2.4.x, `alias_method` is private.

So would you please use `alias` instead of `alias_method` or solve this problem in another way?